### PR TITLE
Dynamiczne pokazywanie aktualnego roku w stopce

### DIFF
--- a/plpug/templates/base.html
+++ b/plpug/templates/base.html
@@ -58,6 +58,6 @@
     </div>
     <footer>
         <p>VPS udostępnia nam <a href="http://www.adminotaur.pl">Adminotaur</a></p>
-        <p>Copyright &copy; 2014-2017 by PLPUG</p>
+        <p>Copyright &copy; 2014-{% now "Y" %} by PLPUG</p>
     </footer>
 {% endblock %}


### PR DESCRIPTION
Dzięki tej zmianie w stopce pokazany będzie zakres dat od 2014 do aktualnego roku i nie będzie trzeba pamiętać o zmianie co roku. Fixes #5 